### PR TITLE
Add OT Forms Plugin

### DIFF
--- a/open-ticket/ot-forms/README.md
+++ b/open-ticket/ot-forms/README.md
@@ -1,0 +1,121 @@
+# OT Forms
+This plugin allows you to create advanced forms with 4 types of questions (short text, paragraph text, dropdown and buttons). You can add unlimited questions to a form.
+
+This README explains how to configure forms for the OT plugin using the provided JSON structure. 
+The configuration allows for highly customizable forms, including various question types like text, dropdowns and buttons.
+
+## Structure of the Configuration File
+Each form in the configuration file is defined as a JSON object with the following fields:
+
+### Form-Level Properties
+- **`id`**: A unique identifier for the form. 
+  - Example: `"example-form"`.
+
+- **`name`**: The name of the form.
+  - Example: `"Example Form"`.
+
+- **`description`**: A brief description of the form (optional).
+  - Example: `"This is an example form (or leave it empty)"`.
+
+- **`color`**: A hexadecimal color code representing the form's visual theme.
+  - Example: `"#99DD99"`.
+
+- **`responsesChannel`**: The ID of the channel where responses will be sent.
+  - Example: `"1331729987518201916"`.
+
+- **`OTTicketAutoSend`**: An array of Open Ticket tickets IDs where the form will be auto-sent when a user creates a ticket of this type.
+  - Example: `["example-ticket-1", "example-ticket-2"]`.
+
+### Questions Section
+The `questions` array defines the form's questions. Each question object includes the following properties:
+
+#### Common Question Properties
+1. **`number`**: The question's unique number in the form.
+2. **`question`**: The text of the question.
+3. **`type`**: Specifies the question type. Supported values are:
+   - `"short"`: Short answer (single line) by a discord modal.
+   - `"long"`: Paragraph answer (multiple lines) by a discord modal.
+   - `"dropdown"`: Dropdown menu with multiple options. It lets you select single or multiple answers.
+   - `"button"`: Button options.
+
+#### Type Text Properties
+For questions of type `short` or `long`:
+- **`optional`**: A boolean indicating if the question is optional (`true`) or required (`false`).
+- **`placeholder`**: A text placeholder for the response input (optional).
+
+#### Dropdown-Specific Properties
+For questions of type `dropdown`:
+- **`minAnswerOptions`**: The minimum number of options a user must select.
+- **`maxAnswerOptions`**: The maximum number of options a user can select.
+- **`placeholder`**: A text placeholder for the response input (optional).
+- **`options`**: An array of dropdown options. Each option includes:
+  - **`option`**: The text of the option.
+  - **`emoji`**: An emoji to display with the option (optional).
+  - **`description`**: A description of the option (optional).
+
+#### Button-Specific Properties
+For questions of type `button`:
+- **`options`**: An array of button options. Each button includes:
+  - **`option`**: The text of the button.
+  - **`emoji`**: An emoji to display with the button (optional).
+  - **`color`**: The button's color. Supported values: `"gray"`, `"red"`, `"green"`, `"blue"`.
+
+### Example Form
+```json
+{
+    "id": "example-form",
+    "name": "Example Form",
+    "description": "This is an example form (or leave it empty)",
+    "color": "#99DD99",
+    "responsesChannel": "channel id where the responses will be sent",
+    "OTTicketAutoSend": ["example-ticket", "ticket id"],
+    "questions": [
+        {
+            "number": 1,
+            "question": "That's an example of short answer question? You can add as many questions as you want.",
+            "type": "short",
+            "optional": false,
+            "placeholder": "Single line response, no paragraphs allowed. (or leave it empty)"
+        },
+        {
+            "number": 2,
+            "question": "That's an example of paragraph answer question?",
+            "type": "long",
+            "optional": false,
+            "placeholder": "Multiple lines response, paragraphs allowed. (or leave it empty)"
+        },
+        {
+            "number": 4,
+            "question": "That's an example of multiple options dropdown question?",
+            "type": "dropdown",
+            "placeholder": "You can select only one option from the dropdown",
+            "minAnswerOptions": 1,
+            "maxAnswerOptions": 1,
+            "options": [
+                {
+                    "option": "This is the first option.",
+                    "emoji": "emoji (or leave it empty)",
+                    "description": "description (or leave it empty)"
+                },
+                {
+                    "option": "And this is the second option. You can add up to 25 options...",
+                    "emoji": "emoji (or leave it empty)",
+                    "description": "description (or leave it empty)"
+                }
+            ]
+        }
+    ]
+}
+```
+
+## Notes
+1. Each form must have a unique `id`.
+2. The maximum number of dropdown or button options is 25.
+3. Use meaningful and concise placeholders to guide users.
+4. Keep required questions clear to ensure proper response handling.
+5. A form does not have a question limit. But try to make it as shorter as you can so the user can answer in a short time.
+6. You can add as many forms as you want.
+7. The forms will be sent automatically when a user creates a ticket wich id is on the `OTTicketAutoSend` field.
+8. You can also send a form using the slash command `/form send <form> <channel>`.
+
+By following this structure, you can create robust and flexible forms with the OT plugin.

--- a/open-ticket/ot-forms/builders/buttonBuilders.ts
+++ b/open-ticket/ot-forms/builders/buttonBuilders.ts
@@ -1,0 +1,90 @@
+import { api, openticket } from "#opendiscord";
+
+// BUTTONS
+openticket.events.get("onButtonBuilderLoad").listen((buttons) => {
+    buttons.add(new api.ODButton("ot-forms:start-form-button"));
+    buttons.get("ot-forms:start-form-button").workers.add(
+        new api.ODWorker("ot-forms:start-form-button", 0, (instance, params, source, cancel) => {
+            const { formId, enabled } = params;
+            const label = enabled ? "Answer" : "Form Answered";
+            instance.setMode("button");
+            instance.setColor("green");
+            instance.setEmoji("📝");
+            instance.setLabel(label);
+            instance.setDisabled(!enabled);
+            instance.setCustomId(`ot-forms:sb_${formId}`);
+        })
+    );
+
+    buttons.add(new api.ODButton("ot-forms:continue-button"));
+    buttons.get("ot-forms:continue-button").workers.add(
+        new api.ODWorker("ot-forms:continue-button", 0, (instance, params, source, cancel) => {
+            const { formId, sessionId } = params;
+            instance.setMode("button");
+            instance.setColor("green");
+            instance.setEmoji("➡️");
+            instance.setLabel("Continue");
+            instance.setCustomId(`ot-forms:cb_${formId}_${sessionId}`);   
+        })
+    );
+
+    buttons.add(new api.ODButton("ot-forms:delete-answers-button"));
+    buttons.get("ot-forms:delete-answers-button").workers.add(
+        new api.ODWorker("ot-forms:delete-answers-button", 0, (instance, params, source, cancel) => {
+            const { formId, sessionId } = params;
+            instance.setMode("button");
+            instance.setColor("red");
+            instance.setEmoji("🗑️");
+            instance.setLabel("Eliminar");
+            instance.setCustomId(`ot-forms:db_${formId}_${sessionId}`);
+        })
+    );
+
+    buttons.add(new api.ODButton("ot-forms:question-button"));
+    buttons.get("ot-forms:question-button").workers.add(
+        new api.ODWorker("ot-forms:question-button", 0, (instance, params, source, cancel) => {
+            const { formId, sessionId, option } = params;
+            const emoji = option.emoji ? option.emoji : null;
+            instance.setMode("button");
+            instance.setColor(option.color);
+            instance.setEmoji(emoji);
+            instance.setLabel(option.option);
+            instance.setCustomId(`ot-forms:qb_${formId}_${sessionId}_${option.option}`);
+        })
+    );
+
+    // PAGINATION BUTTONS
+    buttons.add(new api.ODButton("ot-forms:next-page-button"));
+    buttons.get("ot-forms:next-page-button").workers.add(
+        new api.ODWorker("ot-forms:next-page-button", 0, (instance, params, source, cancel) => {
+            const { currentPageNumber } = params;
+            instance.setMode("button");
+            instance.setColor("gray");
+            instance.setEmoji("▶️");
+            instance.setCustomId(`ot-forms:npb_${currentPageNumber}`);
+        })
+    );
+
+    buttons.add(new api.ODButton("ot-forms:previous-page-button"));
+    buttons.get("ot-forms:previous-page-button").workers.add(
+        new api.ODWorker("ot-forms:previous-page-button", 0, (instance, params, source, cancel) => {
+            const { currentPageNumber } = params;
+            instance.setMode("button");
+            instance.setColor("gray");
+            instance.setEmoji("◀️");
+            instance.setCustomId(`ot-forms:ppb_${currentPageNumber}`);
+        })
+    );
+
+    buttons.add(new api.ODButton("ot-forms:page-number-button"));
+    buttons.get("ot-forms:page-number-button").workers.add(
+        new api.ODWorker("ot-forms:page-number-button", 0, (instance, params, source, cancel) => {
+            const { currentPageNumber, totalPages } = params;
+            instance.setMode("button");
+            instance.setColor("gray");
+            instance.setDisabled(true);
+            instance.setLabel(`Page ${currentPageNumber}/${totalPages}`);
+            instance.setCustomId(`ot-forms:pnb_${currentPageNumber}`);
+        })
+    );
+});

--- a/open-ticket/ot-forms/builders/commandBuilders.ts
+++ b/open-ticket/ot-forms/builders/commandBuilders.ts
@@ -1,0 +1,61 @@
+import { api, openticket } from "#opendiscord";
+import * as discord from "discord.js";
+
+//REGISTER SLASH COMMAND
+const act = discord.ApplicationCommandType
+const acot = discord.ApplicationCommandOptionType
+openticket.events.get("onSlashCommandLoad").listen((slash) => {
+    const config = openticket.configs.get("ot-forms:config")
+
+    //create form choices
+    const formChoices : {name:string, value:string}[] = []
+    config.data.forEach((form) => {
+        formChoices.push({name:form.name,value:form.id})
+    })
+    
+    slash.add(new api.ODSlashCommand("ot-forms:form",{
+        name:"form",
+        description:"Send a form.",
+        type:act.ChatInput,
+        contexts:[discord.InteractionContextType.Guild],
+        integrationTypes:[discord.ApplicationIntegrationType.GuildInstall],
+        options:[
+            {
+                type:acot.Subcommand,
+                name:"send",
+                description:"Send a form to a channel.",
+                options:[
+                    {
+                        type:acot.String,
+                        name:"id",
+                        description:"The form to send.",
+                        required:true,
+                        choices:formChoices
+                    },
+                    {
+                        type:acot.Channel,
+                        name:"channel",
+                        description:"The channel to send the form.",
+                        required:true,
+                        channelTypes:[discord.ChannelType.GuildText,discord.ChannelType.GuildAnnouncement]
+                    }
+                ]
+            }
+        ]
+    },(current) => {
+        //check if this slash command needs to be updated
+        if (!current.options) return true
+
+        const sendSubcommand = current.options.find((opt) => opt.name == "send") as discord.ApplicationCommandSubCommandData|undefined
+        if (!sendSubcommand || !sendSubcommand.options) return true
+
+        const idOption = sendSubcommand.options.find((opt) => opt.name == "id" && opt.type == acot.String) as discord.ApplicationCommandStringOptionData|undefined
+        if (!idOption || !idOption.choices || idOption.choices.length != formChoices.length) return true
+        else if (!formChoices.every((embed) => {
+            if (!idOption.choices) return false
+            else if (!idOption.choices.find((choice) => choice.value == embed.value && choice.name == embed.name)) return false
+            else return true
+        })) return true
+        else return false
+    }))
+})

--- a/open-ticket/ot-forms/builders/dropdownBuilders.ts
+++ b/open-ticket/ot-forms/builders/dropdownBuilders.ts
@@ -1,0 +1,26 @@
+import { api, openticket } from "#opendiscord";
+
+// DROPDOWNS
+openticket.events.get("onDropdownBuilderLoad").listen((dropdowns) => {
+    dropdowns.add(new api.ODDropdown("ot-forms:question-dropdown"));
+    dropdowns.get("ot-forms:question-dropdown").workers.add(
+        new api.ODWorker("ot-forms:question-dropdown", 0, (instance, params, source, cancel) => {
+            const { formId, sessionId, options, minValues, maxValues, placeholder } = params;
+
+            const parsedOptions = options.map((option) => {
+                return {
+                    label:option.option,
+                    value:option.option,
+                    emoji:option.emoji ? option.emoji : undefined,
+                    description:option.description ? option.description : undefined,
+                }
+            })
+            instance.setCustomId(`ot-forms:qd_${formId}_${sessionId}`);
+            instance.setType("string");
+            instance.setMaxValues(maxValues ? maxValues : 1);
+            instance.setMinValues(minValues ? minValues : 1);
+            instance.setPlaceholder(placeholder);
+            instance.setOptions(parsedOptions);
+        })
+    );
+});

--- a/open-ticket/ot-forms/builders/embedBuilders.ts
+++ b/open-ticket/ot-forms/builders/embedBuilders.ts
@@ -1,0 +1,76 @@
+import { api, openticket } from "#opendiscord";
+
+// EMBEDS
+openticket.events.get("onEmbedBuilderLoad").listen((embeds) => {
+
+    /* START FORM EMBED
+     * The embed that shows the initial form message with the Answer button.
+     */
+    embeds.add(new api.ODEmbed("ot-forms:start-form-embed"));
+    embeds.get("ot-forms:start-form-embed").workers.add(
+        new api.ODWorker("ot-forms:start-form-embed", 0, async (instance, params, source, cancel) => {
+            const { formName, formDescription, formColor } = params;
+            instance.setTitle(formName);
+            instance.setDescription(formDescription);
+            instance.setColor(formColor);
+        })
+    );
+
+    /* CONTINUE EMBED
+     * The embed that shows the continue button for a form.
+     */
+    embeds.add(new api.ODEmbed("ot-forms:continue-embed"));
+    embeds.get("ot-forms:continue-embed").workers.add(
+        new api.ODWorker("ot-forms:continue-embed", 0, async (instance, params, source, cancel) => {
+            const { currentSection, totalSections, formColor } = params;
+            instance.setColor(formColor);
+
+            if(currentSection <= totalSections) { // Initial or partial answers
+                instance.setTitle(`Section ${currentSection-1}/${totalSections} answered!`);
+                instance.setDescription("Continue answering the next questions.");
+
+            } else { // All questions answered
+                instance.setTitle(`Form completed!`);
+                instance.setDescription("You have answered all the questions.");
+            }
+        })
+    );
+
+    /* QUESTION EMBED
+     * The embed that shows a question of a form and offers you the answers.
+     */
+    embeds.add(new api.ODEmbed("ot-forms:question-embed"));
+    embeds.get("ot-forms:question-embed").workers.add(
+        new api.ODWorker("ot-forms:question-embed", 0, async (instance, params, source, cancel) => {
+            const { question, currentSection, totalSections, formColor } = params;
+            instance.setTitle(`Question ${question.number}`);
+            instance.setDescription(question.question);
+            instance.setColor(formColor);
+            instance.setFooter(`Section ${currentSection}/${totalSections}`);
+        })
+    );
+
+    /* ANSWERS EMBED
+     * The embed that shows the answers of a form for a user.
+     */
+    embeds.add(new api.ODEmbed("ot-forms:answers-embed"));
+    embeds.get("ot-forms:answers-embed").workers.add(
+        new api.ODWorker("ot-forms:answers-embed", 0, async (instance, params, source, cancel) => {
+            const { type, user, formColor, fields, timestamp } = params;
+
+            instance.setTitle(`Form Answers`);   
+            instance.setAuthor(`${user.displayName} (ID: ${user.id})`, user.displayAvatarURL());
+            instance.setTimestamp(timestamp);
+            
+            if ( type === "completed"  ) {
+                instance.setColor(formColor);
+                instance.setDescription(`<@${user.id}>`);
+            } else {
+                instance.setColor("#FF0000");
+                instance.setDescription(`<@${user.id}> answering...`);
+            }
+
+            instance.addFields(...fields);
+        })
+    );
+});

--- a/open-ticket/ot-forms/builders/messageBuilders.ts
+++ b/open-ticket/ot-forms/builders/messageBuilders.ts
@@ -1,0 +1,102 @@
+import { api, openticket } from "#opendiscord";
+
+// MESSAGE BUILDERS
+openticket.events.get("onMessageBuilderLoad").listen((messages) => {
+    /* START FORM MESSAGE
+     * The message that shows the initial form message with the Answer button.
+     */
+    messages.add(new api.ODMessage("ot-forms:start-form-message"));
+    messages.get("ot-forms:start-form-message").workers.add(
+        new api.ODWorker("ot-forms:start-form-message", 0, async (instance, params, source, cancel) => {
+            const { formId, formName, formDescription, formColor, acceptAnswers } = params;
+            instance.setEmbeds(
+                await openticket.builders.embeds.getSafe("ot-forms:start-form-embed").build(source, { formName, formDescription, formColor })
+            );
+            instance.addComponent(
+                await openticket.builders.buttons.getSafe("ot-forms:start-form-button").build(source, { formId, enabled: acceptAnswers })
+            );
+        })
+    );
+
+    /* CONTINUE MESSAGE
+     * The message that shows the continue button for a form.
+     */
+    messages.add(new api.ODMessage("ot-forms:continue-message"));
+    messages.get("ot-forms:continue-message").workers.add(
+        new api.ODWorker("ot-forms:continue-message", 0, async (instance, params, source, cancel) => {
+            const { formId, sessionId, currentSection, totalSections, formColor } = params;
+            instance.setEmbeds(
+                await openticket.builders.embeds.getSafe("ot-forms:continue-embed").build(source, { currentSection, totalSections, formColor })
+            );
+            instance.setEphemeral(true);
+            if(currentSection <= totalSections) {
+                instance.addComponent(
+                    await openticket.builders.buttons.getSafe("ot-forms:continue-button").build(source, { formId, sessionId })
+                );
+            }
+        })
+    );
+
+    /* QUESTION MESSAGE
+     * The message that shows a question of a form and offers you the answers.
+     */
+    messages.add(new api.ODMessage("ot-forms:question-message"));
+    messages.get("ot-forms:question-message").workers.add(
+        new api.ODWorker("ot-forms:question-message", 0, async (instance, params, source, cancel) => {
+            const { formId, sessionId, question, currentSection, totalSections, formColor } = params;
+            instance.setEmbeds(
+                await openticket.builders.embeds.getSafe("ot-forms:question-embed").build(source, { question, currentSection, totalSections, formColor })
+            );
+            if ( question.type === "dropdown" ) {
+                instance.addComponent(
+                    await openticket.builders.dropdowns.getSafe("ot-forms:question-dropdown").build(source, { formId, sessionId, options: question.options, minValues: question.minAnswerOptions, maxValues: question.maxAnswerOptions, placeholder: question.placeholder })
+                );
+            } else {
+                for(const option of question.options) {
+                    instance.addComponent(
+                        await openticket.builders.buttons.getSafe("ot-forms:question-button").build(source, { formId, sessionId: sessionId, option })
+                    );
+                };
+            }
+            instance.setEphemeral(true);
+        }
+    ));
+
+    /* ANSWERS MESSAGE
+     * The message that shows the answers of a form for a user.
+     */
+    messages.add(new api.ODMessage("ot-forms:answers-message"));
+    messages.get("ot-forms:answers-message").workers.add(
+        new api.ODWorker("ot-forms:answers-message", 0, async (instance, params, source, cancel) => {
+            const { formId, sessionId, type, currentPageNumber, totalPages, currentPage } = params;
+            instance.setEmbeds(currentPage);
+           
+            if(totalPages > 1) {
+                // Adds pagination buttons
+                if(currentPageNumber > 1) instance.addComponent(await openticket.builders.buttons.getSafe("ot-forms:previous-page-button").build(source, { currentPageNumber }));
+                instance.addComponent(await openticket.builders.buttons.getSafe("ot-forms:page-number-button").build(source, { currentPageNumber, totalPages }));
+                if(currentPageNumber < totalPages) instance.addComponent(await openticket.builders.buttons.getSafe("ot-forms:next-page-button").build(source, { currentPageNumber }));
+            }
+            
+            if ( type === "initial" || type === "partial" ) {
+                // Adds delete answers button
+                instance.addComponent(await openticket.builders.buttons.getSafe("ot-forms:delete-answers-button").build(source, { formId, sessionId }));
+            } else {
+                instance.removeComponent("ot-forms:delete-answers-button");
+            }
+
+            
+        })
+    );
+
+    /* SUCCESS COMMAND MESSAGE
+     * The message that shows a success message after sending a form using the slash command.
+     */
+    messages.add(new api.ODMessage("ot-forms:success-message"))
+    messages.get("ot-forms:success-message").workers.add(
+        new api.ODWorker("ot-forms:success-message",0,async (instance,params,source,cancel) => {
+            instance.setContent("✅ The form has been sent successfully!")
+            instance.setEphemeral(true)
+        })
+    )
+});

--- a/open-ticket/ot-forms/builders/modalBuilders.ts
+++ b/open-ticket/ot-forms/builders/modalBuilders.ts
@@ -1,0 +1,26 @@
+import { api, openticket } from "#opendiscord";
+
+// MODALS
+openticket.events.get("onModalBuilderLoad").listen((modals) => {
+    modals.add(new api.ODModal("ot-forms:questions-modal"))
+    modals.get("ot-forms:questions-modal").workers.add(
+        new api.ODWorker("ot-forms:questions-modal",0,async (instance,params,source) => {
+            const { formId, sessionId, formName, questions, currentSection, totalSections } = params;
+
+            const questionsId = questions.map(q => `${q.number}/${q.optional ? 0 : 1}`).join('-');
+
+            instance.setCustomId(`ot-forms:qm_${formId}_${sessionId}_${questionsId}`); 
+            instance.setTitle(`${formName} - ${currentSection}/${totalSections}`);
+            for (const question of questions) {
+                instance.addQuestion({
+                    customId:`${question.number}`,
+                    label:question.question,
+                    style:question.type === 'long' ? "paragraph" : "short",
+                    maxLength:1017,
+                    required:!question.optional,
+                    placeholder:question.placeholder ? question.placeholder : undefined,
+                });
+            }
+        })
+    )
+});

--- a/open-ticket/ot-forms/classes/AnswersManager.ts
+++ b/open-ticket/ot-forms/classes/AnswersManager.ts
@@ -1,0 +1,270 @@
+import { api, openticket } from "#opendiscord";
+import * as discord from "discord.js";
+import { OTForms_Question } from "../types/configDefaults";
+
+const MAX_EMBED_SIZE = 6000;
+const MAX_EMBED_FIELDS = 25;
+
+/**## OTForms_AnswersManager `class`
+ * This is an OT Forms plugin answers message manager.
+ * 
+ * It is responsible for rendering the entire answers message.
+ */
+export class OTForms_AnswersManager {
+    private static _instances: Map<string, OTForms_AnswersManager> = new Map();
+    private formId: string;
+    private sessionId: string;
+    private _message: discord.Message<boolean> | null;
+    private pages: api.ODEmbedBuildResult[];
+    private source: "button" | "other";
+    private _type: "initial" | "partial" | "completed";
+    private _user: discord.User;
+    private _formColor: discord.ColorResolvable;
+    private _answers: { question: OTForms_Question, answer: string | null }[];
+    private _currentPage: number = 1;
+    private timestamp: Date = new Date();
+
+    constructor(formId: string, sessionId: string, source: "button" | "other", type: "initial" | "partial" | "completed", user: discord.User, formColor: discord.ColorResolvable, answers: { question: OTForms_Question, answer: string | null }[]) {
+        this.formId = formId;
+        this.sessionId = sessionId;
+        this._message = null;
+        this.pages = [];
+        this.source = source;
+        this._type = type;
+        this._user = user;
+        this._formColor = formColor;
+        this._answers = answers;
+    }
+
+    get message(): discord.Message<boolean> | null {
+        return this._message;
+    }
+
+    get user(): discord.User {
+        return this._user;
+    }
+    
+    get formColor(): discord.ColorResolvable {
+        return this._formColor;
+    }
+
+    set type(type: "initial" | "partial" | "completed") {
+        this._type = type;
+    }
+
+    set answers(answers: { question: OTForms_Question, answer: string | null }[]) {
+        this._answers = answers;
+    }
+
+    /* getInstance
+     * Returns the instance of the answers message manager.
+     */
+    static getInstance(messageId: string): OTForms_AnswersManager | undefined {
+        return OTForms_AnswersManager._instances.get(messageId);
+    }
+
+    /* removeInstance
+     * Removes the instance of the answers message manager.
+     */
+    static removeInstance(messageId: string): void {
+        OTForms_AnswersManager._instances.delete(messageId);
+    }
+
+    /* render
+     * Renders the answers message.
+     */
+    async render(): Promise<void> {
+        this.pages = await this.splitAnswersIntoEmbeds(this.source, this._type, this._user, this._formColor, this._answers);
+    }
+
+    /* send
+     * Sends the answers message.
+     */
+    async sendMessage(channel: discord.GuildTextBasedChannel, pageNumber: number = this._currentPage): Promise<void> {
+        if(this.pages.length === 0) return;
+        this._currentPage = pageNumber;
+        this._message = await channel.send((await openticket.builders.messages.getSafe("ot-forms:answers-message").build(this.source, { formId: this.formId, sessionId: this.sessionId, type: this._type, currentPageNumber: pageNumber, totalPages: this.pages.length, currentPage: this.pages[pageNumber - 1] })).message);
+        const message = this._message;
+        if(!message) return;
+        OTForms_AnswersManager._instances.set(message.id, this);
+        await this.save();
+    }
+
+    /* setPage
+     * Sets the page of the answers message.
+     */
+    async editMessage(pageNumber: number = this._currentPage): Promise<void> {
+        if(!this._message) return;
+        this._currentPage = pageNumber;
+        await this._message.edit((await openticket.builders.messages.getSafe("ot-forms:answers-message").build(this.source, { formId: this.formId, sessionId: this.sessionId, type: this._type, currentPageNumber: pageNumber, totalPages: this.pages.length, currentPage: this.pages[pageNumber - 1] })).message);
+        await this.save();
+    }
+
+    /* getEmbedSize
+     * Returns the size of an embed in characters.
+     */
+    private getEmbedSize = (embed: discord.EmbedBuilder | null): number => {
+        return JSON.stringify(embed).length;
+    };
+
+    /* splitAnswersIntoEmbeds
+     * Splits the answers into multiple embeds if the total size exceeds the Discord limit.
+     */
+    private async splitAnswersIntoEmbeds(source: "button" | "other", type: "initial" | "partial" | "completed", user: discord.User, formColor: discord.ColorResolvable, answers: { question: OTForms_Question, answer: string | null }[]): Promise<api.ODEmbedBuildResult[]> {
+        let embeds: api.ODEmbedBuildResult[] = [];
+        let currentEmbedStructure: api.ODEmbedBuildResult;
+        let currentEmbed: discord.EmbedBuilder | null;
+
+        let fields: api.ODEmbedData["fields"] = [];
+
+        for (const answer of answers) {
+            // Limit the question to 256 characters on the embed field title
+            const fieldName = answer.question.question.length > 256 ? answer.question.question.slice(0, 252) + "..." : answer.question.question;
+            // Answer are already limited to 1017 characters so are considered safe to use
+            const fieldValue = answer.answer || "Unanswered question.";
+            fields.push({ name: fieldName, value: `\`\`\`${fieldValue}\`\`\``, inline: false });
+
+            // Creates a new embed with the new field
+            currentEmbedStructure = await openticket.builders.embeds.getSafe("ot-forms:answers-embed").build(source, { type, user, formColor, fields, timestamp: this.timestamp });
+            currentEmbed = currentEmbedStructure.embed;
+            if(!currentEmbed) return embeds;
+            // Checks the size of the new embed
+            const newEmbedSize = this.getEmbedSize(currentEmbed);
+            const embedFields = currentEmbed.data.fields;
+            if(!embedFields) return embeds;
+    
+            // If the total size exceeds the 6000 characters limit or the fields are more than 25, creates a new embed
+            if (newEmbedSize > MAX_EMBED_SIZE || embedFields.length >= MAX_EMBED_FIELDS) {
+                fields.pop();
+                currentEmbedStructure = await openticket.builders.embeds.getSafe("ot-forms:answers-embed").build(source, { type, user, formColor, fields, timestamp: this.timestamp });
+                embeds.push(currentEmbedStructure);
+                fields = [{ name: fieldName, value: `\`\`\`${fieldValue}\`\`\`` }];
+            }
+        };
+  
+        // Adds the last embed
+        if (fields.length > 0) {
+            currentEmbedStructure = await openticket.builders.embeds.getSafe("ot-forms:answers-embed").build(source, { type, user, formColor, fields, timestamp: this.timestamp });
+            embeds.push(currentEmbedStructure);
+        }
+    
+        return embeds;
+    };
+
+    /* save
+     * Saves the answers message to the database so the AnswersManager could be restored if bot restarts.
+     */
+    private async save(): Promise<void> {
+        // Save the answers message to the database
+        const data: {
+            formId: string,
+            sessionId: string,
+            messageId: string | null,
+            source: "button" | "other",
+            type: "initial" | "partial" | "completed",
+            userId: string,
+            formColor: discord.ColorResolvable,
+            answers: { question: OTForms_Question, answer: string | null }[],
+            currentPage: number,
+            timestamp: Date
+        } = {
+            formId: this.formId,
+            sessionId: this.sessionId,
+            messageId: this._message ? this._message.id : null,
+            source: this.source,
+            type: this._type,
+            userId: this._user.id,
+            formColor: this._formColor,
+            answers: this._answers,
+            currentPage: this._currentPage,
+            timestamp: this.timestamp
+        };
+
+        const channelId = this._message ? this._message.channel.id : null;
+        const messageId = this._message ? this._message.id : null;
+
+        openticket.databases.get("openticket:global").set("ot-forms:answers-manager", `${channelId}_${messageId}`, data);
+    }
+
+    /* restore
+     * Restores the answers message from the database.
+     */
+    static async restore(): Promise<void> {
+        const globalDatabase = openticket.databases.get("openticket:global")
+        const answersManagerCategory = await globalDatabase.getCategory("ot-forms:answers-manager") ?? [];
+
+        for (const answersManagerData of answersManagerCategory) {
+            const data: {
+                formId: string,
+                sessionId: string,
+                messageId: string | null,
+                source: "button" | "other",
+                type: "initial" | "partial" | "completed",
+                userId: string,
+                formColor: discord.ColorResolvable,
+                answers: { question: OTForms_Question, answer: string | null }[],
+                currentPage: number,
+                timestamp: Date
+            } = answersManagerData.value;
+
+            const formId = data.formId;
+            const sessionId = data.sessionId;
+            const messageId = data.messageId;
+            const source = data.source;
+            const type = data.type;
+            const userId = data.userId;
+            const formColor = data.formColor;
+            const answers = data.answers;
+            const currentPage = data.currentPage;
+
+            const user = await openticket.client.client.users.fetch(userId);
+
+            const channelId = answersManagerData.key.split("_")[0];
+            let channel: discord.Channel | null;
+            try {
+                channel = await openticket.client.client.channels.fetch(channelId);
+            } catch (error) {
+                openticket.log("Channel not found for restoring answers manager. Form answers will not be restored.", "plugin", [
+                    {key:"channel", value:channelId}
+                ]);
+                globalDatabase.delete("ot-forms:answers-manager", `${channelId}_${messageId}`);
+                return;
+            }
+            if(!channel || !channel.isTextBased()) {
+                openticket.log("Channel not found for restoring answers manager. Form answers will not be restored.", "plugin", [
+                    {key:"channel", value:channelId}
+                ]);
+                return;
+            }
+            
+            if(!messageId) {
+                openticket.log("Message ID not found for restoring answers manager. Form answers will not be restored.", "plugin");
+                return;
+            }
+            let message: discord.Message | null;
+            try {
+                message = await channel.messages.fetch(messageId);
+            } catch (error) {
+                openticket.log("Message not found for restoring answers manager. Form answers will not be restored.", "plugin", [
+                    {key:"message", value:messageId}
+                ]);
+                globalDatabase.delete("ot-forms:answers-manager", `${channelId}_${messageId}`);
+                return;
+            }
+
+            if (!message) {
+                openticket.log("Message not found for restoring answers manager. Form answers will not be restored.", "plugin", [
+                    {key:"message", value:messageId}
+                ]);
+                return;
+            }
+
+            const answersManager = new OTForms_AnswersManager(formId, sessionId, source, type, user, formColor, answers);
+            answersManager._currentPage = currentPage;
+            answersManager.timestamp = data.timestamp;
+            answersManager._message = message;
+            await answersManager.render();
+            OTForms_AnswersManager._instances.set(message.id, answersManager);
+        }
+    }
+}

--- a/open-ticket/ot-forms/classes/Form.ts
+++ b/open-ticket/ot-forms/classes/Form.ts
@@ -1,0 +1,88 @@
+import * as discord from "discord.js"
+import { openticket } from "#opendiscord"
+import { OTForms_Question } from "../types/configDefaults"
+import { OTForms_FormSession } from "./FormSession"
+
+/* FORM CLASS
+ * This is the main class of a form (every form message sent is a OTForms_Form). 
+ * A single form on the config can have multiple OTForms_Form instances. It contains all the information of a form.
+ * Creates and manages OTForms_FormSession.
+ */
+export class OTForms_Form {
+    id: string;
+    message: discord.Message<boolean>;
+    name: string;
+    color: discord.ColorResolvable;
+    questions: OTForms_Question[];
+    answersChannel: discord.GuildTextBasedChannel;
+    totalSections: number;
+    private activeSessions: Map<string, OTForms_FormSession>;
+    private sessionCounter: number = 0;
+
+    constructor(formId: string, message: discord.Message<boolean>, name: string, color: discord.ColorResolvable, startMessage: discord.Message<true>, questions: OTForms_Question[], answersChannel: discord.GuildTextBasedChannel) {
+        this.id = formId;
+        this.message = message;
+        this.name = name;
+        this.color = color;
+        this.questions = questions;
+        this.answersChannel = answersChannel;
+        this.activeSessions = new Map<string, OTForms_FormSession>();
+
+        // Calculate total sections
+        this.totalSections = 0;
+        let lastQuestionType: "short" | "long" | "dropdown" | "button" | undefined;
+        let typeTextCount = 1;
+        questions.forEach((question) => {
+            if (question.type !== "short" && question.type !== "long") {
+                // If it's not type text ("short" or "long"), it counts as a section
+                this.totalSections++;
+            } else {
+                // If it's type text, it only counts as a section if the last question wasn't text
+                if (typeTextCount === 5 || (lastQuestionType !== "short" && lastQuestionType !== "long")) {
+                    this.totalSections++;
+                    typeTextCount = 1;
+                } else {
+                    typeTextCount++;
+                }
+            }
+            lastQuestionType = question.type;
+        });
+    }
+
+    /* CREATE SESSION
+     * Creates a new session for a user to answer the form.
+     */
+    public createSession(user: discord.User, message: discord.Message): OTForms_FormSession {
+        if(!this.totalSections) throw new Error("Total sections not calculated");
+        const sessionId = this.generateSessionId();
+
+        const session = new OTForms_FormSession(sessionId, user, this);
+        this.activeSessions.set(sessionId, session);
+        return session;
+    }
+
+    /* FINALIZE SESSION
+     * Removes a session from the active sessions.
+     */
+    public finalizeSession(sessionId: string, formName: string, user: discord.User): void {
+        this.activeSessions.delete(sessionId);
+        openticket.log(`Form session removed.`, "plugin", [
+            {key:"Form", value:formName},
+            {key:"User", value:user.tag}
+        ])
+    }
+
+    /* GENERATE SESSION ID
+     * Generates a new session id.
+     */
+    private generateSessionId(): string {
+        return `ot-forms:session-${this.sessionCounter++}`;
+    }
+
+    /* GET SESSION
+     * Returns a session by its id.
+    */
+    public getSession(sessionId:string): OTForms_FormSession | undefined {
+        return this.activeSessions.get(sessionId);
+    }
+}

--- a/open-ticket/ot-forms/classes/FormSession.ts
+++ b/open-ticket/ot-forms/classes/FormSession.ts
@@ -1,0 +1,305 @@
+import { api, openticket } from "#opendiscord"
+import * as discord from "discord.js"
+import { OTForms_Question, OTForms_ButtonQuestion, OTForms_DropdownQuestion, OTForms_ModalQuestion } from "../types/configDefaults"
+import { OTForms_Form } from "./Form"
+import { OTForms_AnswersManager } from "./AnswersManager"
+
+/* FORM SESSION CLASS
+ * This is the main clas of a form session (every user answering a form is a OTForms_FormSession).
+ * A single user can have multiple OTForms_FormSession instances.
+ * Sends form questions and manage answers.
+ */
+export class OTForms_FormSession {
+    private id: string;
+    user: discord.User;
+    private form: OTForms_Form;
+    private currentSection: number = 1;
+    private currentQuestionNumber: number = 0;
+    private answers: { question: OTForms_Question, answer: string | null }[] = [];
+    private instance: api.ODButtonResponderInstance | api.ODDropdownResponderInstance | api.ODModalResponderInstance | undefined;
+    private answersManager: OTForms_AnswersManager | undefined;
+    private sessionMessage: api.ODMessageBuildSentResult<boolean> | null = null;
+
+    constructor(id: string, user: discord.User, form: OTForms_Form) {
+        this.id = id;
+        this.user = user;
+        this.form = form;
+    }
+
+    /* START FORM SESSION
+     * Starts the form session. Sends the first question to the user.
+     */
+    public async start(): Promise<void> {
+        await this.sendNextQuestion();
+    }
+
+    /* CONTINUE FORM SESSION
+     * Moves to the next step on the form session. It sends the next question, the continue message or finalize the session.
+     */
+    public async continue(mode:"question" | "continue"): Promise<void> {
+        if(this.currentQuestionNumber >= this.form.questions.length) {
+            this.currentSection++;
+            await this.finalize();
+            return;
+        } else if(mode === "question") {
+            await this.sendNextQuestion();
+            return;
+        } else if(mode === "continue") {
+            this.currentSection++;
+            await this.sendContinueMessage();
+            return;
+        } else {
+            this.currentSection++;
+            await this.finalize();
+            return;
+        }
+    }
+
+    /* HANDLE RESPONSE
+     * Handles the response of a type button or dropdown question. 
+     * Stores the answer and sends the next question.
+     */
+    private handleResponse(answers: { question: OTForms_Question; answer: string | null; }[]): void {
+        this.currentQuestionNumber++;
+        this.answers = this.answers.concat(answers);
+        this.updateAnswersMessage();
+        this.continue("continue");
+    }
+
+    /* HANDLE BUTTON RESPONSE
+     * Handles the response of a button question.
+     */
+    public async handleButtonResponse(response: string): Promise<void> {
+        const question = this.form.questions[this.currentQuestionNumber];
+        const answers = [{ question, answer: response }];
+        this.handleResponse(answers);
+    }
+
+    /* HANDLE DROPDOWN RESPONSE
+     * Handles the response of a dropdown question.
+     */
+    public async handleDropdownResponse(response: api.ODDropdownResponderInstanceValues): Promise<void> {
+        const question = this.form.questions[this.currentQuestionNumber];
+        const answer = response.getStringValues().join(", ");
+        const answers = [{ question, answer }];
+        this.handleResponse(answers);
+    }
+
+    /* HANDLE MODAL RESPONSE
+     * Handles the response of a modal question.
+     */
+    public async handleModalResponse(response: api.ODModalResponderInstanceValues, answeredQuestions: { number: number; required: boolean; }[]): Promise<void> {
+        const answers = answeredQuestions.map(q => ({
+            question: this.form.questions[q.number-1],
+            answer: q.required 
+                    ? response.getTextField(q.number.toString(), true)
+                    : response.getTextField(q.number.toString(), false)
+        }))
+        this.currentQuestionNumber = this.currentQuestionNumber + answers.length - 1;
+        this.handleResponse(answers);
+    }
+
+    /* SET INSTANCE
+     * Sets the instance of the current interaction for the form session.
+     */
+    public async setInstance(instance: api.ODButtonResponderInstance | api.ODDropdownResponderInstance | api.ODModalResponderInstance, onlyIfNotSessionMessage: boolean = false) {
+        if(!onlyIfNotSessionMessage) this.instance = instance;
+        else if(!this.sessionMessage) {
+            this.instance = instance
+        } else {
+            await instance.defer("update", true);
+        }
+    }
+
+    /* SEND NEXT QUESTION
+     * Sends the next question to the user.
+     */
+    private async sendNextQuestion(): Promise<void> {
+        const question = this.form.questions[this.currentQuestionNumber];
+        switch (question.type) {
+            case 'short':
+            case 'long':
+                await this.sendModalQuestions();
+                break;
+            case 'dropdown':
+                await this.sendDropdownQuestion(question as OTForms_DropdownQuestion);
+                break;
+            case 'button':
+                await this.sendButtonQuestion(question as OTForms_ButtonQuestion);
+                break;
+            default:
+                console.error('Tipus de pregunta desconegut:', question.type);
+        }
+    }
+
+    /* MODAL QUESTIONS
+     * Sends a modal with maximum 5 question to the user. Questions are added to the modal only if they are consecutive.
+     */
+    private async sendModalQuestions(): Promise<void> {
+        const modalQuestions: OTForms_ModalQuestion[] = [];
+        let count = 0;
+
+        if(!this.instance || this.instance.didReply) {
+            openticket.log("Error: Modal questions have not been sent. Instance not found or already replied.", "plugin");
+            return;
+        }
+
+        if(!(this.instance instanceof api.ODButtonResponderInstance)) {
+            openticket.log("Error: Modal questions have not been sent. Current instance is not valid for modals.", "plugin");
+            return;
+        }
+        
+        // Max 5 questions per modal
+        while (count < 5 && this.currentQuestionNumber + 1 <= this.form.questions.length) {
+            const question = this.form.questions[this.currentQuestionNumber + count];
+            if (question.type !== "short" && question.type !== "long") break;
+            modalQuestions.push(question as OTForms_ModalQuestion);
+            count++;
+        }
+
+        // Show modal
+        await this.instance.modal(
+            await openticket.builders.modals.getSafe("ot-forms:questions-modal").build("other", {
+                formId: this.form.id,
+                sessionId: this.id,
+                formName: this.form.name,
+                questions: modalQuestions,
+                currentSection: this.currentSection,
+                totalSections: this.form.totalSections
+            })
+        );
+    }
+
+    /* DROPDOWN QUESTION
+     * Sends a dropdown question to the user.
+     */
+    private async sendDropdownQuestion(question: OTForms_DropdownQuestion): Promise<void> {
+        if(!this.instance) {
+            openticket.log("Error: Dropdown question has not been sent. Interaction not found.", "plugin");
+            return;
+        }
+
+        const message = await openticket.builders.messages.getSafe("ot-forms:question-message").build("other", {
+            formId: this.form.id,
+            sessionId: this.id,
+            question: question,
+            currentSection: this.currentSection,
+            totalSections: this.form.totalSections,
+            formColor: this.form.color
+        });
+
+        if(!this.sessionMessage) {
+            // Send dropdown question message
+            if(this.instance.didReply) {
+                openticket.log("Error: Dropdown question has not been sent. Interaction already replied.", "plugin");
+                return;
+            }
+            this.sessionMessage = await this.instance.reply(message);
+        } else {
+            // Update to dropdown question message
+            this.instance.update(message);
+        }
+    }
+
+    /* BUTTON QUESTION
+     * Sends a button question to de user.
+     */
+    private async sendButtonQuestion(question: OTForms_ButtonQuestion): Promise<void> {
+        if(!this.instance) {
+            openticket.log("Error: Button question has not been sent. Interaction not found.", "plugin");
+            return;
+        }
+
+        const message = await openticket.builders.messages.getSafe("ot-forms:question-message").build("other", {
+            formId: this.form.id,
+            sessionId: this.id,
+            question: question,
+            currentSection: this.currentSection,
+            totalSections: this.form.totalSections,
+            formColor: this.form.color
+        });
+
+        if(!this.sessionMessage) {
+            // Send button question message
+            if(this.instance.didReply) {
+                openticket.log("Error: Button question has not been sent. Interaction already replied.", "plugin");
+                return;
+            }
+            this.sessionMessage = await this.instance.reply(message);
+        } else {
+            // Update to button question message
+            this.instance.update(message);
+        }
+    }
+
+    /* CONTINUE MESSAGE
+     * Sends a continue message to the user. The message between sections.
+     */
+    private async sendContinueMessage(): Promise<void> {
+        if(!this.instance) {
+            openticket.log("Error: The continue message has not been sent. Interaction not found.", "plugin");
+            return;
+        }
+
+        const message = await openticket.builders.messages.getSafe("ot-forms:continue-message").build("button", {
+            formId:this.form.id,
+            sessionId: this.id,
+            currentSection: this.currentSection,
+            totalSections: this.form.totalSections,
+            formColor: this.form.color
+        });
+
+        if(!this.sessionMessage) {
+            // Send continue message
+            this.sessionMessage = await this.instance.reply(message);
+        } else {
+            // Update to continue message
+            this.instance.update(message);
+        }
+    }
+
+    /* UPDATE ANSWERS MESSAGE
+     * Updates the answers message with the current answers. It's the message that stores all the answers of the user.
+     */
+    private async updateAnswersMessage(): Promise<void> {
+        if(!this.answersManager) {
+            this.answersManager = new OTForms_AnswersManager(this.form.id, this.id, "other", "initial", this.user, this.form.color, this.answers);
+            await this.answersManager.render();
+            await this.answersManager.sendMessage(this.form.answersChannel);
+        } else {
+            const type: "initial" | "partial" | "completed" = this.currentQuestionNumber >= this.form.questions.length ? "completed" : "partial";
+            this.answersManager.answers = this.answers;
+            this.answersManager.type = type;
+
+            await this.answersManager.render();
+            await this.answersManager.editMessage();
+        }
+    }
+
+    /* FINALIZE FORM SESSION
+     * Sends the final message to the user.
+     */
+    private async finalize(): Promise<void> {
+        if(this.instance) {
+            const message = await openticket.builders.messages.getSafe("ot-forms:continue-message").build("button", {
+                formId:this.form.id,
+                sessionId: this.id,
+                currentSection: this.currentSection,
+                totalSections: this.form.totalSections,
+                formColor: this.form.color
+            });
+
+            if(this.sessionMessage) {
+                // Update to continue message
+                this.instance.update(message);
+            } else {
+                // Send continue message
+                this.sessionMessage = await this.instance.reply(message);
+            }
+        }
+        openticket.log(`Form answered.`, "plugin", [
+            {key:"Form", value:this.form.name},
+            {key:"User", value:this.user.tag}
+        ])
+    }
+}

--- a/open-ticket/ot-forms/config.json
+++ b/open-ticket/ot-forms/config.json
@@ -1,0 +1,124 @@
+[
+    {
+        "id":"example-form",
+        "name":"Example Form",
+        "description":"This is an example form (or leave it empty)",
+        "color":"#99DD99",
+        
+        "responsesChannel":"channel id where the responses will be sent",
+        "OTTicketAutoSend":["example-ticket", "ticket id"],
+        
+        "questions":[
+            {
+                "number":1,
+                "question":"That's an example of short answer question? You can add as many questions as you want.",
+                "type":"short",
+                "optional":false,
+                "placeholder":"Single line response, no paragraphs allowed. (or leave it empty)"
+            },
+            {
+                "number":2,
+                "question":"That's an example of paragraph answer question?",
+                "type":"long",
+                "optional":false,
+                "placeholder":"Multiple lines response, paragraphs allowed. (or leave it empty)"
+            },
+            {
+                "number":3,
+                "question":"That's an example of optional question?",
+                "type":"short",
+                "optional":true,
+                "placeholder":"This is an optional question. You can skip it if you want. (or leave it empty)"
+            },
+            {
+                "number":4,
+                "question":"That's an example of multiple options dropdown question?",
+                "type":"dropdown",
+                
+                "placeholder": "You can select only one option from the dropdown",
+                "minAnswerOptions":1,
+                "maxAnswerOptions":1,
+                "options":[
+                    {
+                        "option":"This is the first option.",
+                        "emoji":"emoji (or leave it empty)",
+                        "description":"description (or leave it empty)"
+                    },
+                    {
+                        "option":"And this is the second option. You can add up to 25 options...",
+                        "emoji":"emoji (or leave it empty)",
+                        "description":"description (or leave it empty)"
+                    }
+                ]
+            },
+            {
+                "number":5,
+                "question":"That's another dropdown question? But now you can select multiple options.",
+                "type":"dropdown",
+                
+                "placeholder": "You have to select at least 2 options and can select up to 3",
+                "minAnswerOptions":2,
+                "maxAnswerOptions":3,
+                "options":[
+                    {
+                        "option":"That's the first option.",
+                        "emoji":"emoji (or leave it empty)",
+                        "description":"description (or leave it empty)"
+                    },
+                    {
+                        "option":"That's the second option.",
+                        "emoji":"emoji (or leave it empty)",
+                        "description":"description (or leave it empty)"
+                    },
+                    {
+                        "option":"That's the third option.",
+                        "emoji":"emoji (or leave it empty)",
+                        "description":"description (or leave it empty)"
+                    }
+                ]
+            },
+            {
+                "number":6,
+                "question":"That's an example of multiple options questions with buttons? ",
+                "type":"button",
+                
+                "options":[
+                    {
+                        "option":"That's a button option.",
+                        "emoji":"emoji (or leave it empty)",
+                        "color": "gray, red, green or blue"
+                    },
+                    {
+                        "option":"Another button. You can select only one option by clicking on the button.",
+                        "emoji":"emoji (or leave it empty)",
+                        "color":"gray, red, green or blue"
+                    },
+                    {
+                        "option":"And another button. You can add up to 25 options...",
+                        "emoji":"emoji (or leave it empty)",
+                        "color":"gray, red, green or blue"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "id":"example-form-2",
+        "name":"Example Form 2. You can add as forms as you want.",
+        "description":"description (or leave it empty)",
+        "color":"#99DD99 (or leave it empty)",
+        
+        "responsesChannel":"channel id where the responses will be sent",
+        "OTTicketAutoSend":["example-ticket", "ticket id"],
+        
+        "questions":[
+            {
+                "number":1,
+                "question":"Question 1?",
+                "type":"long",
+                "optional":false,
+                "placeholder":"placeholder (or leave it empty)"
+            }      
+        ]
+    }
+]

--- a/open-ticket/ot-forms/configManager/checkerStructures.ts
+++ b/open-ticket/ot-forms/configManager/checkerStructures.ts
@@ -1,0 +1,56 @@
+import { api } from "#opendiscord";
+
+export const formsConfigStructure = new api.ODCheckerArrayStructure("ot-forms:forms",{allowedTypes:["object"],propertyChecker:new api.ODCheckerObjectStructure("ot-forms:forms",{children:[
+    // FORMS MAIN STRUCTURE
+    {key:"id",optional:false,priority:0,checker:new api.ODCheckerCustomStructure_UniqueId("ot-forms:form-id","ot-forms","form-id",{regex:/^[A-Za-z0-9-éèçàêâôûîñ]+$/,minLength:3,maxLength:20})},
+    {key:"name",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:form-name",{minLength:1,maxLength:45})},
+    {key:"description",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:form-description",{maxLength:4096})},
+    {key:"color",optional:false,priority:0,checker:new api.ODCheckerCustomStructure_HexColor("ot-forms:form-color",true,false)},
+
+    {key:"responsesChannel",optional:false,priority:0,checker:new api.ODCheckerCustomStructure_DiscordId("ot-forms:responses-channel","channel",true,[],{})}, // Empty allowed
+    
+    {key:"OTTicketAutoSend",optional:false,priority:0,checker:new api.ODCheckerCustomStructure_UniqueIdArray("ot-forms:auto-send-ticket","openticket","option-ids","option-ids-used",{allowDoubles:false,maxLength:25})},
+
+    // QUESTIONS STRUCTURE
+    {key:"questions",optional:false,priority:0,checker:new api.ODCheckerArrayStructure("ot-forms:questions",{allowedTypes:["object"],minLength:1,propertyChecker:new api.ODCheckerObjectSwitchStructure("ot-forms:questions",{objects:[
+        // TYPE SHORT QUESTION STRUCTURE
+        {name:"short",priority:0,properties:[{key:"type",value:"short"}],checker:new api.ODCheckerObjectStructure("ot-forms:short-question",{children:[
+            {key:"number",optional:false,priority:0,checker:new api.ODCheckerNumberStructure("ot-forms:question-number",{min:1})},
+            {key:"question",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question",{minLength:1,maxLength:45})},
+            {key:"optional",optional:false,priority:0,checker:new api.ODCheckerBooleanStructure("ot-forms:question-optional",{})},
+            {key:"placeholder",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question-placeholder",{maxLength:100})}
+        ]})},
+        // TYPE LONG QUESTION STRUCTURE
+        {name:"long",priority:0,properties:[{key:"type",value:"long"}],checker:new api.ODCheckerObjectStructure("ot-forms:long-question",{children:[
+            {key:"number",optional:false,priority:0,checker:new api.ODCheckerNumberStructure("ot-forms:question-number",{min:1})},
+            {key:"question",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question",{minLength:1,maxLength:45})},
+            {key:"optional",optional:false,priority:0,checker:new api.ODCheckerBooleanStructure("ot-forms:question-optional",{})},
+            {key:"placeholder",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question-placeholder",{maxLength:100})}
+        ]})},
+        // TYPE DROPDOWN QUESTION STRUCTURE
+        {name:"dropdown",priority:0,properties:[{key:"type",value:"dropdown"}],checker:new api.ODCheckerObjectStructure("ot-forms:dropdown-question",{children:[
+            {key:"number",optional:false,priority:0,checker:new api.ODCheckerNumberStructure("ot-forms:question-number",{min:1})},
+            {key:"question",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question",{minLength:1,maxLength:4096})},
+            {key:"placeholder",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question-placeholder",{maxLength:150})},
+            {key:"minAnswerOptions",optional:false,priority:0,checker:new api.ODCheckerNumberStructure("ot-forms:question-min-options",{min:0,max:25})},
+            {key:"maxAnswerOptions",optional:false,priority:0,checker:new api.ODCheckerNumberStructure("ot-forms:question-max-options",{min:1,max:25})},
+            // OPTIONS STRUCTURE
+            {key:"options",optional:false,priority:0,checker:new api.ODCheckerArrayStructure("ot-forms:question-options",{allowedTypes:["object"],minLength:1,maxLength:25,propertyChecker:new api.ODCheckerObjectStructure("ot-forms:question-options",{children:[
+                {key:"option",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question-option",{minLength:1,maxLength:100})},
+                {key:"description",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question-option-description",{maxLength:100})},
+                {key:"emoji",optional:false,priority:0,checker:new api.ODCheckerCustomStructure_EmojiString("forms:question-option-emoji",0,1,true)},
+            ]})})}
+        ]})},
+        // TYPE BUTTON QUESTION STRUCTURE
+        {name:"button",priority:0,properties:[{key:"type",value:"button"}],checker:new api.ODCheckerObjectStructure("ot-forms:button-question",{children:[
+            {key:"number",optional:false,priority:0,checker:new api.ODCheckerNumberStructure("ot-forms:question-number",{min:1})},
+            {key:"question",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question",{minLength:1,maxLength:4096})},
+            // OPTIONS STRUCTURE
+            {key:"options",optional:false,priority:0,checker:new api.ODCheckerArrayStructure("ot-forms:question-options",{allowedTypes:["object"],minLength:1,maxLength:25,propertyChecker:new api.ODCheckerObjectStructure("ot-forms:question-options",{children:[
+                {key:"option",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question-option",{minLength:1,maxLength:40})},
+                {key:"color",optional:false,priority:0,checker:new api.ODCheckerStringStructure("ot-forms:question-option-color",{choices:["gray","red","green","blue"]})},
+                {key:"emoji",optional:false,priority:0,checker:new api.ODCheckerCustomStructure_EmojiString("forms:question-option-emoji",0,1,true)},
+            ]})})},
+        ]})}
+    ]})})}
+]})})

--- a/open-ticket/ot-forms/configManager/configRegistration.ts
+++ b/open-ticket/ot-forms/configManager/configRegistration.ts
@@ -1,0 +1,13 @@
+import { api, openticket } from "#opendiscord";
+import { formsConfigStructure } from "./checkerStructures";
+
+// CONFIG REGISTRATION
+openticket.events.get("onConfigLoad").listen((configManager) => {
+    configManager.add(new api.ODJsonConfig("ot-forms:config", "config.json", "./plugins/ot-forms/"));
+});
+
+// CHECKER REGISTRATION
+openticket.events.get("onCheckerLoad").listen((checkerManager) => {
+    const config = openticket.configs.get("ot-forms:config");
+    checkerManager.add(new api.ODChecker("ot-forms:config",checkerManager.storage,0,config,formsConfigStructure)); 
+});

--- a/open-ticket/ot-forms/index.ts
+++ b/open-ticket/ot-forms/index.ts
@@ -1,0 +1,301 @@
+import {api, openticket, utilities} from "#opendiscord"
+import * as discord from "discord.js"
+import { OTForms_Form } from "./classes/Form"
+import { OTForms_AnswersManager } from "./classes/AnswersManager";
+
+import "./configManager/configRegistration";
+import "./builders/messageBuilders";
+import "./builders/embedBuilders";
+import "./builders/buttonBuilders";
+import "./builders/modalBuilders";
+import "./builders/dropdownBuilders";
+import "./builders/commandBuilders";
+
+if (utilities.project != "openticket") throw new api.ODPluginError("This plugin only works in Open Ticket!")
+
+const forms = new Map<string, OTForms_Form>();
+
+/* READY FOR USAGE EVENT
+ * When the plugin is ready for usage, sort the questions of each form by their number.
+ */
+openticket.events.get("onReadyForUsage").listen(async () => {
+    const formsConfig = openticket.configs.get("ot-forms:config").data;
+    for(const formConfig of formsConfig) {
+        formConfig.questions.sort((a, b) => a.number - b.number);
+    }
+});
+
+openticket.events.get("afterCodeExecuted").listen(async () => {
+    openticket.log("Plugin \"ot-forms\" restoring answers...", "plugin");
+    await OTForms_AnswersManager.restore();
+})
+
+/* TICKET CREATED EVENT
+ * When a ticket is created, check if the ticket ID is in the list of forms that should be automatically sent.
+ * If it is, send the form to the channel.
+ */
+openticket.events.get("afterTicketCreated").listen(async (ticket, creator, channel) => {
+    const formsConfig = openticket.configs.get("ot-forms:config").data;
+    const ticketId = ticket.option.id.value;
+
+    for(const formConfig of formsConfig) {
+        if (formConfig.OTTicketAutoSend.includes(ticketId)) {
+
+            const startMessageTemplate = await openticket.builders.messages.getSafe("ot-forms:start-form-message").build("ticket", {
+                formId: formConfig.id,
+                formName: formConfig.name,
+                formDescription: formConfig.description,
+                formColor: formConfig.color,
+                acceptAnswers: true
+            });
+
+            const startMessage = await channel.send(startMessageTemplate.message);
+            const answersChannel = await channel.guild.channels.fetch(formConfig.responsesChannel);
+            if(!answersChannel || !answersChannel.isTextBased()) {
+                openticket.log("Error: Invalid answers channel.", "plugin");
+                return;
+            }
+            
+            const questions = formConfig.questions.sort((a, b) => a.number - b.number);
+            const form = new OTForms_Form(formConfig.id, startMessage, formConfig.name, formConfig.color, startMessage, questions, answersChannel);
+            forms.set(formConfig.id, form);
+        }
+    };
+});
+
+//REGISTER COMMAND RESPONDER
+openticket.events.get("onCommandResponderLoad").listen((commands) => {
+    const generalConfig = openticket.configs.get("openticket:general")
+    const formsConfig = openticket.configs.get("ot-forms:config").data;
+
+    /* FORM COMMAND RESPONDER
+     * The command manage forms. Currently limited to sending forms to a channel.
+     */
+    commands.add(new api.ODCommandResponder("ot-forms:form",generalConfig.data.prefix,"form"))
+    commands.get("ot-forms:form").workers.add([
+        new api.ODWorker("ot-forms:form",0,async (instance,params,source,cancel) => {
+            const {guild,channel,user} = instance
+            if (!guild){
+                instance.reply(await openticket.builders.messages.getSafe("openticket:error-not-in-guild").build("button",{channel,user}))
+                return cancel()
+            }
+
+            if (!openticket.permissions.hasPermissions("admin",await openticket.permissions.getPermissions(instance.user,instance.channel,instance.guild))){
+                instance.reply(await openticket.builders.messages.getSafe("openticket:error-no-permissions").build(source,{guild:instance.guild,channel:instance.channel,user:instance.user,permissions:["admin"]}))
+                return cancel()
+            }
+
+            //command doesn't support text-commands!
+            if (source == "text") return cancel()
+            const scope = instance.options.getSubCommand() as "send"
+
+            if (scope == "send"){
+                const formId = instance.options.getString("id",true)
+                const formChannel = instance.options.getChannel("channel",true) as discord.GuildTextBasedChannel
+                
+                const formConfig = formsConfig.find((form) => form.id == formId)
+                if (!formConfig){
+                    instance.reply(await openticket.builders.messages.getSafe("openticket:error").build(source,{guild,channel,user,layout:"simple",error:"Invalid form id. Please try again!"}))
+                    return cancel()
+                }
+
+                const startMessageTemplate = await openticket.builders.messages.getSafe("ot-forms:start-form-message").build("ticket", {
+                    formId: formConfig.id,
+                    formName: formConfig.name,
+                    formDescription: formConfig.description,
+                    formColor: formConfig.color,
+                    acceptAnswers: true
+                });
+
+                const startMessage = await formChannel.send(startMessageTemplate.message);
+                const answersChannel = await guild.channels.fetch(formConfig.responsesChannel);
+                if(!answersChannel || !answersChannel.isTextBased()) {
+                    openticket.log("Error: Invalid answers channel.", "plugin");
+                    return;
+                }
+
+                const questions = formConfig.questions.sort((a, b) => a.number - b.number);
+                const form = new OTForms_Form(formConfig.id, startMessage, formConfig.name, formConfig.color, startMessage, questions, answersChannel);
+                forms.set(formConfig.id, form);
+            }
+
+            await instance.reply(await openticket.builders.messages.getSafe("ot-forms:success-message").build(source,{}))
+        }),
+        new api.ODWorker("ot-forms:logs",-1,(instance,params,source,cancel) => {
+            const scope = instance.options.getSubCommand() as "send"
+            openticket.log(instance.user.displayName+" used the 'form "+scope+"' command!","plugin",[
+                {key:"user",value:instance.user.username},
+                {key:"userid",value:instance.user.id,hidden:true},
+                {key:"channelid",value:instance.channel.id,hidden:true},
+                {key:"method",value:source}
+            ])
+        })
+    ])
+})
+
+//REGISTER HELP MENU
+openticket.events.get("onHelpMenuComponentLoad").listen((menu) => {
+    menu.get("openticket:extra").add(new api.ODHelpMenuCommandComponent("ot-forms:form",0,{
+        slashName:"form send",
+        slashDescription:"Send a form to a channel.",
+    }))
+})
+
+// BUTTON RESPONDER
+openticket.events.get("onButtonResponderLoad").listen((buttons, responders, actions) => {
+    /* START FORM BUTTON RESPONDER
+     * The button to start answering a form.
+     */
+    buttons.add(new api.ODButtonResponder("ot-forms:start-form-button", /^ot-forms:sb_/));
+    openticket.responders.buttons.get("ot-forms:start-form-button").workers.add(new api.ODWorker("ot-forms:start-form-button", 0, async (instance, params, source, cancel) => {
+        const formId = instance.interaction.customId.split("_")[1];
+        const form = forms.get(formId);
+        if (!form) return
+
+        const session = form.createSession(instance.interaction.user, instance.message);
+        await session.setInstance(instance);
+        await session.start();
+    }));
+
+    /* CONTINUE BUTTON RESPONDER
+     * The button between two form questions. To continue to the next section of the form.
+     */
+    buttons.add(new api.ODButtonResponder("ot-forms:continue-button", /^ot-forms:cb_/));
+    openticket.responders.buttons.get("ot-forms:continue-button").workers.add(new api.ODWorker("ot-forms:continue-button", 0, async (instance, params, source, cancel) => {
+        const customIdParts = instance.interaction.customId.split("_");
+        const formId = customIdParts[1];
+        const form = forms.get(formId);
+        if (!form) return
+
+        const sessionId = customIdParts[2];
+
+        const session = form.getSession(sessionId);
+        if (!session) return
+
+        session.setInstance(instance);
+
+        await session.continue("question");
+    }));
+
+    /* DELETE ANSWERS MESSAGE BUTTON RESPONDER
+     * The button to delete a form session. Visible on the answers message until the form is completed.
+     */
+    buttons.add(new api.ODButtonResponder("ot-forms:delete-answers-button", /^ot-forms:db_/));
+    openticket.responders.buttons.get("ot-forms:delete-answers-button").workers.add(new api.ODWorker("ot-forms:delete-answers-button", 0, async (instance, params, source, cancel) => {
+        await instance.defer("update",true);
+        OTForms_AnswersManager.removeInstance(instance.message.id);
+        instance.message.delete();
+
+        const customIdParts = instance.interaction.customId.split("_");
+        const formId = customIdParts[1];
+        const form = forms.get(formId);
+        if (!form) return
+
+        const sessionId = customIdParts[2];
+
+        form.finalizeSession(sessionId, form.name, instance.user);
+    }));
+
+    /* QUESTION BUTTON RESPONDER
+     * A type button question can have multiple question buttons. Every button represents a possible answer.
+     */
+    buttons.add(new api.ODButtonResponder("ot-forms:question-button", /^ot-forms:qb_/));
+    openticket.responders.buttons.get("ot-forms:question-button").workers.add(new api.ODWorker("ot-forms:question-button", 0, async (instance, params, source, cancel) => {
+        const customIdParts = instance.interaction.customId.split("_");
+        const formId = customIdParts[1];
+        const form = forms.get(formId);
+        if (!form) return
+
+        const sessionId = customIdParts[2];
+
+        const session = form.getSession(sessionId);
+        if (!session) return
+
+        session.setInstance(instance);
+
+        const answer = customIdParts[3];
+        await session.handleButtonResponse(answer);
+    }));
+
+    // PAGINATION BUTTONS
+    /* NEXT PAGE BUTTON RESPONDER
+     * The button to go to the next page of the answers message.
+     */
+    buttons.add(new api.ODButtonResponder("ot-forms:next-page-button", /^ot-forms:npb_/));
+    openticket.responders.buttons.get("ot-forms:next-page-button").workers.add(new api.ODWorker("ot-forms:next-page-button", 0, async (instance, params, source, cancel) => {
+        instance.defer("update",true);
+        const answersManager = OTForms_AnswersManager.getInstance(instance.message.id);
+        if (!answersManager) return;
+
+        const currentPageNumber = Number(instance.interaction.customId.split("_")[1]);
+
+        answersManager.editMessage(currentPageNumber + 1);
+    }));
+
+    /* PREVIOUS PAGE BUTTON RESPONDER
+     * The button to go to the previous page of the answers message.
+     */
+    buttons.add(new api.ODButtonResponder("ot-forms:previous-page-button", /^ot-forms:ppb_/));
+    openticket.responders.buttons.get("ot-forms:previous-page-button").workers.add(new api.ODWorker("ot-forms:previous-page-button", 0, async (instance, params, source, cancel) => {
+        instance.defer("update",true);
+        const answersManager = OTForms_AnswersManager.getInstance(instance.message.id);
+        if (!answersManager) return;
+
+        const currentPageNumber = Number(instance.interaction.customId.split("_")[1]);
+
+        answersManager.editMessage(currentPageNumber - 1);
+    }));
+});
+
+// MODAL RESPONDER
+openticket.events.get("onModalResponderLoad").listen((modals, responders, actions) => {
+    /* QUESTIONS MODAL RESPONDER
+     * This modal is used to answer questions of a form.
+     */
+    modals.add(new api.ODModalResponder("ot-forms:questions-modal", /^ot-forms:qm_/));
+    openticket.responders.modals.get("ot-forms:questions-modal").workers.add(new api.ODWorker("ot-forms:questions-modal", 0, async (instance, params, source, cancel) => {
+        const customIdParts = instance.interaction.customId.split("_");
+        const formId = customIdParts[1];
+        const form = forms.get(formId);
+        if (!form) return
+
+        const sessionId = customIdParts[2];
+        const session = form.getSession(sessionId);
+        if (!session) return
+
+        const answeredQuestions: {number: number,required:boolean}[] = customIdParts[3].split('-').map(pair => {
+            const [num, required] = pair.split('/');
+            return {
+                number: Number(num),
+                required: required === '1'
+            };
+        });
+
+        const response = instance.values;
+        session.setInstance(instance, true);
+
+        await session.handleModalResponse(response, answeredQuestions);
+    }));
+})
+
+openticket.events.get("onDropdownResponderLoad").listen((dropdowns, responders, actions) => {
+    /* QUESTION DROPDOWN RESPONDER
+     * This dropdown is used to answer questions of a form. It can be used for multiple choice questions.
+     */
+    dropdowns.add(new api.ODDropdownResponder("ot-forms:question-dropdown", /^ot-forms:qd_/));
+    openticket.responders.dropdowns.get("ot-forms:question-dropdown").workers.add(new api.ODWorker("ot-forms:question-dropdown", 0, async (instance, params, source, cancel) => {
+        const customIdParts = instance.interaction.customId.split("_");
+        const formId = customIdParts[1];
+        const form = forms.get(formId);
+        if (!form) return
+
+        const sessionId = customIdParts[2];
+        const session = form.getSession(sessionId);
+        if (!session) return
+
+        const response = instance.values;
+        session.setInstance(instance);
+        
+        await session.handleDropdownResponse(response);
+    }));
+});

--- a/open-ticket/ot-forms/plugin.json
+++ b/open-ticket/ot-forms/plugin.json
@@ -1,0 +1,23 @@
+{
+    "name":"OT Forms",
+    "id":"ot-forms",
+    "version":"1.0.0",
+    "startFile":"index.ts",
+
+    "enabled":true,
+    "priority":0,
+    "events":[],
+
+    "npmDependencies":[],
+    "requiredPlugins":[],
+    "incompatiblePlugins":[],
+
+    "details":{
+        "author":"guillee.3",
+        "shortDescription":"An advanced forms plugin for OpenTickets.",
+        "longDescription":"This plugin allows you to create advanced forms with 3 types of questions: modal, dropdown and buttons. See README for more information.",
+        "imageUrl":"",
+        "projectUrl":"",
+        "tags":["forms","questions","modal","dropdown","buttons"]
+    }
+}

--- a/open-ticket/ot-forms/types/configDefaults.ts
+++ b/open-ticket/ot-forms/types/configDefaults.ts
@@ -1,0 +1,81 @@
+import { api } from '#opendiscord'
+import * as discord from "discord.js"
+
+/* FORM
+ * This is the main structure of the form
+ */
+interface OTForms_Form {
+    id: string,
+    name: string,
+    description: string,
+    color: discord.ColorResolvable,
+    responsesChannel: string,
+    OTTicketAutoSend: string[],
+    questions: OTForms_Question[]
+}
+
+/* QUESTION
+ * This is the main structure of a question
+ */
+export interface OTForms_Question {
+    number: number,
+    question: string,
+    type: "short" | "long" | "dropdown" | "button",
+}
+
+/* DROPDOWN QUESTION
+ * This is the structure of a question TYPE DROPDOWN
+ */
+export interface OTForms_DropdownQuestion extends OTForms_Question {
+    type: "dropdown",
+    placeholder: string,
+    minAnswerOptions: number,
+    maxAnswerOptions: number,
+    options: OTForms_DropdownOption[]
+}
+
+/* BUTTON QUESTION
+ * This is the structure of a question TYPE BUTTON
+ */
+export interface OTForms_ButtonQuestion extends OTForms_Question {
+    type: "button",
+    options: OTForms_ButtonOption[]
+}
+
+/* MODAL QUESTION
+ * This is the structure of a question TYPE MODAL
+ */
+export interface OTForms_ModalQuestion extends OTForms_Question {
+    type: "short" | "long",
+    placeholder: string,
+    optional: boolean,
+}
+
+/* OPTION
+ * This is the structure of an answer option for a question
+ */
+export interface OTForms_Option {
+    option: string,
+    emoji: string
+}
+
+/* BUTTON OPTION
+ * This is the structure of an answer option for a question TYPE BUTTON
+ */
+export interface OTForms_ButtonOption extends OTForms_Option {
+    color: api.ODValidButtonColor
+}
+
+/* DROPDOWN OPTION
+ * This is the structure of an answer option for a question TYPE DROPDOWN
+ */
+export interface OTForms_DropdownOption extends OTForms_Option {
+    description: string
+}
+
+/* DEFAULT FORMS CONFIG
+ * This is the default structure of the forms config
+ */
+export class ODJsonConfig_DefaultForms extends api.ODJsonConfig {
+    declare data: OTForms_Form[]
+}

--- a/open-ticket/ot-forms/types/declarations.ts
+++ b/open-ticket/ot-forms/types/declarations.ts
@@ -1,0 +1,78 @@
+import { api } from "#opendiscord";
+import discord from "discord.js";
+import { ODJsonConfig_DefaultForms, OTForms_Question, OTForms_ButtonQuestion, OTForms_DropdownQuestion, OTForms_ModalQuestion, OTForms_DropdownOption, OTForms_ButtonOption } from "./configDefaults";
+
+declare module "#opendiscord-types" {
+    export interface ODConfigManagerIds_Default {
+        "ot-forms:config":ODJsonConfig_DefaultForms
+    }
+    export interface ODCheckerManagerIds_Default {
+        "ot-forms:config":api.ODChecker
+    }
+    export interface ODSlashCommandManagerIds_Default {
+        "ot-forms:form":api.ODSlashCommand
+    }
+    export interface ODTextCommandManagerIds_Default {
+        "ot-forms:form":api.ODTextCommand
+    }
+    export interface ODCommandResponderManagerIds_Default {
+        "ot-forms:form":{source:"slash"|"text",params:{},workers:"ot-forms:form"|"ot-forms:logs"},
+    }
+    export interface ODMessageManagerIds_Default {
+        "ot-forms:start-form-message": { source: "ticket" | "slash"; params: { formId: string, formName: string, formDescription: string, formColor: discord.ColorResolvable, acceptAnswers: boolean }; workers: "ot-forms:start-form-message" };
+        "ot-forms:continue-message": { source: "button"; params: { formId: string, sessionId: string, currentSection:number, totalSections:number, formColor: discord.ColorResolvable }; workers: "ot-forms:continue-message" };
+        "ot-forms:question-message": { source: "other"; params: { formId: string, sessionId: string, question: OTForms_ButtonQuestion|OTForms_DropdownQuestion, currentSection:number, totalSections:number, formColor: discord.ColorResolvable }; workers: "ot-forms:question-message" };
+        "ot-forms:answers-message": { source: "button" | "other"; params: { formId: string, sessionId: string, type: "initial" | "partial" | "completed", currentPageNumber: number, totalPages: number, currentPage: api.ODEmbedBuildResult }; workers: "ot-forms:answers-message" };
+        "ot-forms:success-message": { source: "slash" | "other"; params: {}; workers: "ot-forms:success-message" };
+    }
+    export interface ODEmbedManagerIds_Default {
+        "ot-forms:start-form-embed": { source: "ticket" | "slash"; params: { formName: string, formDescription: string, formColor: discord.ColorResolvable }; workers: "ot-forms:start-form-embed" };
+        "ot-forms:continue-embed": { source: "button"; params: { currentSection:number, totalSections:number, formColor: discord.ColorResolvable }; workers: "ot-forms:continue-embed" };
+        "ot-forms:question-embed": { source: "other"; params: { question: OTForms_ButtonQuestion|OTForms_DropdownQuestion, currentSection:number, totalSections:number, formColor: discord.ColorResolvable }; workers: "ot-forms:question-embed" };
+        "ot-forms:answers-embed": { source: "button" | "other"; params: { type: "initial" | "partial" | "completed", user: discord.User, formColor: discord.ColorResolvable, fields: api.ODEmbedData["fields"], timestamp: Date }; workers: "ot-forms:answers-embed" };
+    }
+    export interface ODButtonManagerIds_Default {
+        "ot-forms:start-form-button": { source: "ticket" | "slash"; params: { formId: string, enabled: boolean }; workers: "ot-forms:start-form-button" };
+        "ot-forms:continue-button": { source: "button"; params: { formId: string, sessionId: string }; workers: "ot-forms:continue-button" };
+        "ot-forms:question-button": { source: "other"; params: { formId: string, sessionId: string, option: OTForms_ButtonOption }; workers: "ot-forms:question-button" };
+        "ot-forms:delete-answers-button": { source: "button" | "other"; params: { formId: string, sessionId: string }; workers: "ot-forms:delete-answers-button" };
+        "ot-forms:next-page-button": { source: "button" | "other"; params: { currentPageNumber: number }; workers: "ot-forms:next-page-button" };
+        "ot-forms:previous-page-button": { source: "button" | "other"; params: { currentPageNumber: number }; workers: "ot-forms:previous-page-button" };
+        "ot-forms:page-number-button": { source: "button" | "other"; params: { currentPageNumber: number, totalPages: number }; workers: "ot-forms:page-number-button" };
+    }
+    export interface ODButtonResponderManagerIds_Default {
+        "ot-forms:start-form-button":{source:"button",params:{},workers:"ot-forms:start-form-button"},
+        "ot-forms:continue-button":{source:"button",params:{},workers:"ot-forms:continue-button"},
+        "ot-forms:question-button":{source:"button",params:{},workers:"ot-forms:question-button"},
+        "ot-forms:delete-answers-button":{source:"button",params:{},workers:"ot-forms:delete-answers-button"},
+        "ot-forms:next-page-button":{source:"button",params:{},workers:"ot-forms:next-page-button"},
+        "ot-forms:previous-page-button":{source:"button",params:{},workers:"ot-forms:previous-page-button"},
+        "ot-forms:page-number-button":{source:"button",params:{},workers:"ot-forms:page-number-button"},
+    }
+    export interface ODModalManagerIds_Default {
+        "ot-forms:questions-modal":{source:"button"|"panel-button"|"panel-dropdown"|"slash"|"ticket"|"other";params:{ formId: string, sessionId: string, formName:string, questions:OTForms_ModalQuestion[], currentSection:number, totalSections:number };workers:"ot-forms:questions-modal"},
+    }   
+    export interface ODModalResponderManagerIds_Default {
+        "ot-forms:questions-modal":{source:"modal";params:{};workers:"ot-forms:questions-modal"},
+    }
+    export interface ODDropdownManagerIds_Default {
+        "ot-forms:question-dropdown": { source: "other"; params: { formId: string, sessionId: string, options: OTForms_DropdownOption[], minValues: number, maxValues: number, placeholder: string }; workers: "ot-forms:question-dropdown" };
+    }
+    export interface ODDropdownResponderManagerIds_Default {
+        "ot-forms:question-dropdown": { source: "dropdown"; params: { }; workers: "ot-forms:question-dropdown" };
+    }
+    export interface ODFormattedJsonDatabaseIds_DefaultGlobal {
+        "ot-forms:answers-manager":{
+                    formId: string,
+                    sessionId: string,
+                    messageId: string | null,
+                    source: "button" | "other",
+                    type: "initial" | "partial" | "completed",
+                    userId: string,
+                    formColor: discord.ColorResolvable,
+                    answers: { question: OTForms_Question, answer: string | null }[],
+                    currentPage: number,
+                    timestamp: Date
+                },
+    }
+}


### PR DESCRIPTION
Added OT Forms Plugin: This plugin allows you to create forms with an unlimited number of questions, including text, dropdown, or button types. Each form can be attached to a ticket, and it will be sent automatically when the ticket is created, or it can be sent to any channel by slash command.